### PR TITLE
Follow PowerShell convention with PascalCase params

### DIFF
--- a/.github/workflows/pr-windows-script-bad-versions-tests.yml
+++ b/.github/workflows/pr-windows-script-bad-versions-tests.yml
@@ -27,7 +27,7 @@ jobs:
         shell: powershell
         run: |
           try {
-            .\setup-lando.ps1 -version ${{ matrix.bad-version }} -no_setup
+            .\setup-lando.ps1 -Version ${{ matrix.bad-version }} -NoSetup
             exit 1
           } catch {
             exit 0

--- a/.github/workflows/pr-windows-script-shell-tests.yml
+++ b/.github/workflows/pr-windows-script-shell-tests.yml
@@ -23,12 +23,12 @@ jobs:
         name: Execute ps1 with PowerShell 5.1
         shell: powershell
         run: |
-          .\setup-lando.ps1 -debug
+          .\setup-lando.ps1 -Debug
           lando version --all
 
       - if: matrix.shell == 'pwsh'
         name: Execute ps1 with PowerShell 7
         shell: pwsh
         run: |
-          .\setup-lando.ps1 -debug
+          .\setup-lando.ps1 -Debug
           lando version --all

--- a/.github/workflows/pr-windows-script-versions-tests.yml
+++ b/.github/workflows/pr-windows-script-versions-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         fat:
-          - -fat
+          - -Fat
           - ''
         success-version:
           - '3'
@@ -33,12 +33,12 @@ jobs:
       - name: Setup Lando version ${{ matrix.success-version }} ${{ matrix.fat }}
         shell: powershell # 5.1
         run: |
-          .\setup-lando.ps1 -version=${{ matrix.success-version }} -no_setup ${{ matrix.fat }} -Debug
+          .\setup-lando.ps1 -Version=${{ matrix.success-version }} -NoSetup ${{ matrix.fat }} -Debug
           lando version --all
 
           # test slim|fat on lando 3
           if (lando version | Select-String "v3.") {
-            if (${{ matrix.fat }} -eq "-fat") {
+            if (${{ matrix.fat }} -eq "-Fat") {
               lando config --path cli.slim | Select-String "false"
             }
             else {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v3.1.1 - [April 22, 2024](https://github.com/lando/setup-lando/releases/tag/v3.1.1)
+
+### Windows/WSL Install Script
+
+* Updated `windows` installer script switch names to follow PowerShell convention
+
 ## v3.1.0 - [April 22, 2024](https://github.com/lando/setup-lando/releases/tag/v3.1.0)
 
 ### Windows/WSL Install Script

--- a/dist/setup-lando.ps1
+++ b/dist/setup-lando.ps1
@@ -6,7 +6,7 @@ Lando Windows Installer Script.
 This script is used to download and install Lando on Windows. It also installs Lando in all WSL2 instances.
 
 .EXAMPLE
-.\setup-lando.ps1 -arch x64 -version edge
+.\setup-lando.ps1 -Arch x64 -version edge
 Installs Lando with the x64 architecture and the edge version.
 
 .EXAMPLE
@@ -23,25 +23,25 @@ Installs Lando on Windows only, skipping the WSL setup.
 param(
     # Specifies the architecture to install (x64 or arm64). Defaults to the system architecture.
     [ValidateSet("x64", "arm64")]
-    [string]$arch = "x64",
+    [string]$Arch = "x64",
     # Enables debug output.
-    [switch]$debug,
+    [switch]$Debug,
     # Specifies the destination path for installation. Defaults to "$env:USERPROFILE\.lando\bin".
     [ValidateNotNullOrEmpty()]
     [string]$dest = "$env:USERPROFILE\.lando\bin",
     # Download the fat v3 lando binary that comes with official plugins built-in.
-    [switch]$fat,
+    [switch]$Fat,
     # Skips running Lando's built-in setup script.
-    [switch]$no_setup,
+    [switch]$NoSetup,
     # Skips the WSL setup.
-    [switch]$no_wsl,
+    [switch]$NoWSL,
     # Resumes a previous installation after a reboot.
     [switch]$resume,
     # Specifies the version of Lando to install. Defaults to "stable".
     [ValidateNotNullOrEmpty()]
     [string]$version = "stable",
     # Only installs Lando in WSL.
-    [switch]$wsl_only,
+    [switch]$WSLOnly,
     # Displays the help message.
     [switch]$help
 )
@@ -62,9 +62,9 @@ Set-StrictMode -Version 1
 $ErrorActionPreference = "Stop"
 
 # Normalize debug preference
-$DebugPreference = If ($debug) { "Continue" } Else { $DebugPreference }
+$DebugPreference = If ($Debug) { "Continue" } Else { $DebugPreference }
 if ($DebugPreference -eq "Inquire" -or $DebugPreference -eq "Continue") {
-    $debug = $true
+    $Debug = $true
 }
 $Host.PrivateData.DebugForegroundColor = "Gray"
 $Host.PrivateData.DebugBackgroundColor = $Host.UI.RawUI.BackgroundColor
@@ -109,10 +109,10 @@ function Confirm-Environment {
     }
     if (-not $wslVersion) {
         Write-Debug "WSL is not installed."
-        if (-not $no_wsl) {
+        if (-not $NoWSL) {
             $Script:no_wsl = $true
         }
-        if ($wsl_only) {
+        if ($WSLOnly) {
             throw "WSL is not installed. Cannot install Lando in WSL."
         }
     }
@@ -123,28 +123,28 @@ function Select-Architecture {
     $procArch = $(if ($Env:PROCESSOR_ARCHITEW6432) { $Env:PROCESSOR_ARCHITEW6432 } Else { $Env:PROCESSOR_ARCHITECTURE })
     Write-Debug "Processor architecture: $procArch"
 
-    if (-not $arch) {
-        $arch = "x64"  # Default architecture is x64
+    if (-not $Arch) {
+        $Arch = "x64"  # Default architecture is x64
         if ($procArch -eq "ARM64") {
-            $arch = "arm64"
+            $Arch = "arm64"
         }
     }
-    Write-Debug "Selected architecture: $arch"
+    Write-Debug "Selected architecture: $Arch"
 
-    if ($arch -notmatch "x64|arm64") {
+    if ($Arch -notmatch "x64|arm64") {
         throw "Unsupported architecture provided. Only x64 and arm64 are supported."
     }
 
-    if ($arch -eq "x64" -and $procArch -eq "ARM64") {
+    if ($Arch -eq "x64" -and $procArch -eq "ARM64") {
         $script:issueEncountered = $true
         Write-Warning "You are attempting to install the x64 version of Lando on an arm64 system. This may not work."
     }
-    if ($arch -eq "arm64" -and $procArch -eq "AMD64") {
+    if ($Arch -eq "arm64" -and $procArch -eq "AMD64") {
         $script:issueEncountered = $true
         Write-Warning "You are attempting to install the arm64 version of Lando on an x64 system. This may not work."
     }
 
-    return $arch
+    return $Arch
 }
 
 # Checks for existing Lando installation and uninstalls it
@@ -206,16 +206,16 @@ function Resolve-VersionAlias {
     }
 
     # Resolve release aliases to download URLs.
-    # Default to slim variant for 3.x unless -fat is specified.
+    # Default to slim variant for 3.x unless -Fat is specified.
     switch -Regex ($Version) {
         "^(3|4)-(stable|edge)$" {
             Write-Debug "Fetching release alias '$($Version.ToUpper())' from GitHub..."
             $VersionLabel = (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/lando/cli/main/release-aliases/$($Version.ToUpper())" -UseBasicParsing).Content -replace '\s'
-            $variant = if ($Version -match "^3-" -and !$fat) { "-slim" } else { "" }
+            $variant = if ($Version -match "^3-" -and !$Fat) { "-slim" } else { "" }
             $downloadUrl = "${baseUrl}${VersionLabel}/lando-win-${arch}-${VersionLabel}${variant}.exe"
         }
         "^(3|4)-dev$" {
-            $variant = if ($Version -match "^3-" -and !$fat) { "-slim" } else { "" }
+            $variant = if ($Version -match "^3-" -and !$Fat) { "-slim" } else { "" }
             $downloadUrl = "https://files.lando.dev/cli/lando-win-${arch}-${Version}${variant}.exe"
         }
         Default {
@@ -400,7 +400,7 @@ function Install-Lando {
         $QuotedPath = '"{0}"' -f $symlinkPath
         $QuotedTarget = '"{0}"' -f $downloadDest
         $mklink = @('mklink', $QuotedPath, $QuotedTarget)
-        (-not $debug -and ($mklink += @('>nul', '2>&1'))) | Out-Null
+        (-not $Debug -and ($mklink += @('>nul', '2>&1'))) | Out-Null
 
         # Try to create the link
         Write-Debug "> $($mklink -join ' ')"
@@ -410,7 +410,7 @@ function Install-Lando {
         if ($process.ExitCode) {
             Write-Debug "Symlink creation failed with exit code $($process.ExitCode). Trying hard link..."
             $mklink = @('mklink', '/H', $QuotedPath, $QuotedTarget)
-            (-not $debug -and ($mklink += @('>nul', '2>&1'))) | Out-Null
+            (-not $Debug -and ($mklink += @('>nul', '2>&1'))) | Out-Null
 
             Write-Debug "> $($mklink -join ' ')"
             $process = Start-Process -FilePath 'cmd.exe' -ArgumentList "/D /C $($mklink -join ' ')" -NoNewWindow -Wait -PassThru
@@ -430,7 +430,7 @@ function Install-Lando {
 
     # Clear the cache so that new Lando commands are available
     $landoClearCommand = "$symlinkPath --clear"
-    ($debug -and ($landoClearCommand += " --debug")) | Out-Null
+    ($Debug -and ($landoClearCommand += " --debug")) | Out-Null
     Write-Debug "Running '$landoClearCommand'"
     try {
         Invoke-Expression $landoClearCommand
@@ -469,16 +469,16 @@ function Install-LandoInWSL {
 
     # We will pass some of our parameters to the setup script in WSL
     $setupParams = @()
-    if ($debug) {
+    if ($Debug) {
         $setupParams += "--debug"
     }
-    if ($arch) {
-        $setupParams += "--arch=$arch"
+    if ($Arch) {
+        $setupParams += "--arch=$Arch"
     }
-    if ($fat) {
+    if ($Fat) {
         $setupParams += "--fat"
     }
-    if ($no_setup) {
+    if ($NoSetup) {
         $setupParams += "--no-setup"
     }
     if ($version) {
@@ -529,7 +529,7 @@ function Invoke-LandoSetup {
     }
 
     $landoSetupCommand = "$dest\lando.exe setup -y"
-    ($debug -and ($landoSetupCommand += " --debug")) | Out-Null
+    ($Debug -and ($landoSetupCommand += " --debug")) | Out-Null
 
     Write-Debug "Running '$landoSetupCommand'"
     try {
@@ -550,15 +550,15 @@ if ([string]::IsNullOrEmpty($SCRIPT_VERSION)) {
 }
 
 Write-Debug "Running script $SCRIPT_VERSION with:"
-Write-Debug "  -arch: $arch"
-Write-Debug "  -debug: $debug"
+Write-Debug "  -Arch: $Arch"
+Write-Debug "  -debug: $Debug"
 Write-Debug "  -dest: $dest"
-Write-Debug "  -fat: $fat"
-Write-Debug "  -no_setup: $no_setup"
-Write-Debug "  -no_wsl: $no_wsl"
+Write-Debug "  -Fat: $Fat"
+Write-Debug "  -NoSetup: $NoSetup"
+Write-Debug "  -no_wsl: $NoWSL"
 Write-Debug "  -resume: $resume"
 Write-Debug "  -version: $version"
-Write-Debug "  -wsl_only: $wsl_only"
+Write-Debug "  -wsl_only: $WSLOnly"
 Write-Debug "  -help: $help"
 
 # It's okay to ask for help
@@ -575,7 +575,7 @@ if ($resume) {
 Confirm-Environment
 
 # Select the appropriate architecture
-$arch = Select-Architecture
+$Arch = Select-Architecture
 
 # Set up our working directory
 if (-not (Test-Path "$LANDO_APPDATA" -ErrorAction SilentlyContinue)) {
@@ -586,7 +586,7 @@ if (-not (Test-Path "$LANDO_APPDATA" -ErrorAction SilentlyContinue)) {
 # Add a RunOnce registry key so Windows will automatically resume the script when interrupted by a reboot
 $runOnceKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce"
 $runOnceName = "LandoSetup"
-if (-not $wsl_only -and -not $resume) {
+if (-not $WSLOnly -and -not $resume) {
     # When the script is invoked from a piped web request, the script path is not available.
     # Detect this and save the script to a known location so it can be resumed after a reboot.
     $localScriptPath = $MyInvocation.MyCommand.Path
@@ -598,12 +598,12 @@ if (-not $wsl_only -and -not $resume) {
     }
 
     # Install Lando in Windows
-    if (-not $wsl_only) {
+    if (-not $WSLOnly) {
         Uninstall-LegacyLando
 
         Install-Lando
 
-        if (-not $no_setup) {
+        if (-not $NoSetup) {
             # Dependency installation may trigger a reboot so make sure we can resume after
             $resumeCommand = Get-ResumeCommand $localScriptPath $MyInvocation.BoundParameters
 
@@ -624,13 +624,13 @@ if (-not $wsl_only -and -not $resume) {
 }
 
 # Lando setup may have been interrupted by the reboot. Run it again.
-if ($resume -and -not $no_setup -and -not $wsl_only) {
+if ($resume -and -not $NoSetup -and -not $WSLOnly) {
     Invoke-LandoSetup
 }
 
 # Install in WSL after lando setup runs because Docker Desktop WSL
 # instances may not be available until after reboot.
-if (-not $no_wsl) {
+if (-not $NoWSL) {
     Install-LandoInWSL
 }
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -27,31 +27,31 @@ Invoke-WebRequest -Uri 'https://get.lando.dev/setup-lando.ps1' -OutFile 'setup-l
 Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser
 
 # Show usage info:
-.\setup-lando.ps1 -help
+.\setup-lando.ps1 -Help
 
 # An example advanced invocation:
-.\setup-lando.ps1 -dest 'C:\Users\aaron\bin' -fat -version 3.22.1 -debug
+.\setup-lando.ps1 -Dest 'C:\Users\aaron\bin' -Fat -Version 3.22.1 -Debug
 ```
 
 ### Usage
 
 ```powershell
-.\setup-lando.ps1 [-arch <x64|arm64>] [-debug] [-dest <path>] [-fat] [-no_setup] [-no_wsl] [-resume] [-version <version>] [-wsl_only] [-help]
+.\setup-lando.ps1 [-Arch <x64|arm64>] [-Debug] [-Dest <path>] [-Fat] [-NoSetup] [-NoWSL] [-Resume] [-Version <version>] [-WSLOnly] [-Help]
 ```
-- `-arch <x64|arm64>`: Specifies the architecture to install (x64 or arm64). Defaults to the system architecture.
-- `-debug`: Enables debug output.
-- `-dest <path>`: Specifies the destination path for installation. Defaults to "$env:USERPROFILE\.lando\bin".
-- `-fat`: Download the fat v3 Lando binary that comes with official plugins built-in.
-- `-no_setup`: Skips running Lando's built-in setup script.
-- `-no_wsl`: Skips the Windows Subsystem for Linux (WSL) setup.
-- `-resume`: Resumes a previous installation after a reboot.
-- `-version <version>`: Specifies the version of Lando to install. Defaults to "stable".
-- `-wsl_only`: Only installs Lando in WSL.
-- `-help`: Displays the help message.
+- `-Arch <x64|arm64>`: Specifies the architecture to install (x64 or arm64). Defaults to the system architecture.
+- `-Debug`: Enables debug output.
+- `-Dest <path>`: Specifies the destination path for installation. Defaults to "$env:USERPROFILE\.lando\bin".
+- `-Fat`: Download the fat v3 Lando binary that comes with official plugins built-in.
+- `-NoSetup`: Skips running Lando's built-in setup script.
+- `-NoWSL`: Skips the Windows Subsystem for Linux (WSL) setup.
+- `-Resume`: Resumes a previous installation after a reboot.
+- `-Version <version>`: Specifies the version of Lando to install. Defaults to "stable".
+- `-WSLOnly`: Only installs Lando in WSL.
+- `-Help`: Displays the help message.
 
 Some notes on advanced usage:
 
-* If you want to customize the behavior of `lando setup` use `-no_setup` and then manually invoke [`lando setup`](https://docs.lando.dev/cli/setup.html) after install is complete.
+* If you want to customize the behavior of `lando setup` use `-NoSetup` and then manually invoke [`lando setup`](https://docs.lando.dev/cli/setup.html) after install is complete.
 
 ## Performance Note
 


### PR DESCRIPTION
In powershell, parameter names are typically PascalCase. This updates our switches to follow the convention.

I initially wanted to match our posix installer convention, but the built-in handling for switches in PowerShell does not allow hyphens in the names.