### PR TITLE
don't run 'lando update' if version is explicitly provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Providing `--version` no longer runs the update step in the installer (overwriting the selected version)
+
 ## v3.2.2 - [May 17, 2024](https://github.com/lando/setup-lando/releases/tag/v3.2.2)
 
 * Fixed `windows` setup script passing incorrect parameter to `wsl` setup script [#46](https://github.com/lando/setup-lando/issues/44)

--- a/setup-lando.sh
+++ b/setup-lando.sh
@@ -241,10 +241,12 @@ while [[ $# -gt 0 ]]; do
     --version)
       VERSION="$2"
       shift 2
+      VERSION_PROVIDED=1
       ;;
     --version=*)
       VERSION="${1#*=}"
       shift
+      VERSION_PROVIDED=1
       ;;
     -y | --yes)
       NONINTERACTIVE="1"
@@ -774,7 +776,7 @@ if [[ -z "${NONINTERACTIVE-}" ]]; then
   # setup
   if [[ "$SETUP" == "1" ]]; then log "- ${tty_blue}run${tty_reset} ${tty_bold}lando setup${tty_reset}"; fi
   # update
-  log "- ${tty_blue}run${tty_reset} ${tty_bold}lando update${tty_reset}"
+  if [[ -z "$VERSION_PROVIDED" ]]; then log "- ${tty_blue}run${tty_reset} ${tty_bold}lando update${tty_reset}"; fi
   # shellenv
   log "- ${tty_blue}run${tty_reset} ${tty_bold}lando shellenv --add${tty_reset}"
   # block for user
@@ -830,8 +832,10 @@ if [[ "$SETUP" == "1" ]]; then
 fi
 
 # update
-log "${tty_blue}updating${tty_reset} ${tty_bold}lando${tty_reset}"
-execute "${LANDO}" update --yes "${LANDO_DEBUG-}"
+if [[ -z "$VERSION_PROVIDED" ]]; then
+  log "${tty_blue}updating${tty_reset} ${tty_bold}lando${tty_reset}"
+  execute "${LANDO}" update --yes "${LANDO_DEBUG-}"
+fi
 
 # shell env
 log "${tty_blue}adding${tty_reset} ${tty_bold}${DEST}${tty_reset} to ${tty_bold}PATH${tty_reset}"

--- a/setup-lando.sh
+++ b/setup-lando.sh
@@ -776,7 +776,7 @@ if [[ -z "${NONINTERACTIVE-}" ]]; then
   # setup
   if [[ "$SETUP" == "1" ]]; then log "- ${tty_blue}run${tty_reset} ${tty_bold}lando setup${tty_reset}"; fi
   # update
-  if [[ -z "$VERSION_PROVIDED" ]]; then log "- ${tty_blue}run${tty_reset} ${tty_bold}lando update${tty_reset}"; fi
+  if [[ -z "${VERSION_PROVIDED-}" ]]; then log "- ${tty_blue}run${tty_reset} ${tty_bold}lando update${tty_reset}"; fi
   # shellenv
   log "- ${tty_blue}run${tty_reset} ${tty_bold}lando shellenv --add${tty_reset}"
   # block for user
@@ -832,7 +832,7 @@ if [[ "$SETUP" == "1" ]]; then
 fi
 
 # update
-if [[ -z "$VERSION_PROVIDED" ]]; then
+if [[ -z "${VERSION_PROVIDED-}" ]]; then
   log "${tty_blue}updating${tty_reset} ${tty_bold}lando${tty_reset}"
   execute "${LANDO}" update --yes "${LANDO_DEBUG-}"
 fi


### PR DESCRIPTION
### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)

- [x] I've updated this PR with the latest code from `main`
- [x] I've done a cursory QA pass of my code locally
- (I don't think there is one for setup-lando.sh) I've ensured all automated status check and tests pass
- (could not find one which fits) I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- (not necessary / don't have time) I've written a unit or functional test for my code
- (not needed since the new behavior is the naturally expected one) I've updated relevant documentation it my code changes it
- (not needed. They are irrelevant for the readme) I've updated this repo's README if my code changes it
- [x] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- (not sure who to request review from) I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
