### PR TITLE
fix bug causing gh convenience aliases to incorrectly resolve to rele…

### DIFF
--- a/.github/workflows/pr-actions-setup.yml
+++ b/.github/workflows/pr-actions-setup.yml
@@ -64,4 +64,4 @@ jobs:
           telemetry: false
           config: |
             setup.skipCommonPlugins=true
-            setup.plugins.@lando/core=latest
+            setup.plugins.@lando/core=edge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed bug causing GitHub convenience aliases eg `3-edge-slim` to incorrectly resolve to releases with hitherto unpopulated assets
+
 ## v3.4.1 - [October 17, 2024](https://github.com/lando/setup-lando/releases/tag/v3.4.1)
 
 * Fixed bug causing `&&` separated `auto-setup` command strings to not run correctly

--- a/setup-lando.js
+++ b/setup-lando.js
@@ -80,7 +80,7 @@ const main = async () => {
     core.debug(`found ${releases.length} valid releases`);
 
     // attempt to resolve the spec
-    let version = resolveVersionSpec(spec, releases);
+    let version = resolveVersionSpec(spec, releases, 3, inputs);
 
     // throw error if we cannot resolve a version
     if (!version) throw new Error(`Could not resolve "${spec}" into an installable version of Lando`);

--- a/utils/get-download-url.js
+++ b/utils/get-download-url.js
@@ -1,38 +1,16 @@
 'use strict';
 
 const isValidUrl = require('./is-valid-url');
+const getFilename = require('./get-filename');
+
 const {s3Releases} = require('./get-convenience-aliases');
 
 module.exports = (version, {os, architecture, slim = false} = {}) => {
   // if version is actually a downlaod url then just return that right away
   if (isValidUrl(version)) return version;
 
-  // otherwise start by building the lando file string
-  const parts = ['lando'];
-  parts.push(os === 'Windows' ? 'win' : os.toLowerCase());
-  parts.push(architecture.toLowerCase());
-
-  // if version is a dev release from s3
-  // @TODO: we allow s3 convenience aliases with major version stuff eg 4-dev but we dont actually
-  // have those releases labeled in S3, thats fine with just Lando 3 but with Lando 4 we probably need
-  // to have ALL of the below
-  //
-  // https://files.lando.dev/cli/lando-macos-arm64-dev
-  // https://files.lando.dev/cli/lando-macos-arm64-3-dev
-  // https://files.lando.dev/cli/lando-macos-arm64-4-dev
-  //
-  // right now we basically just strip the version
-  if (s3Releases.includes(version)) {
-    // add the s3 alias
-    parts.push(version.split('-').length === 2 ? version.split('-')[1] : version.split('-')[0]);
-  // otherwise append the version
-  } else parts.push(version);
-
-  // add slim if needed
-  if (slim) parts.push('slim');
-
-  // and add special handling for windows
-  const filename = os === 'Windows' ? `${parts.join('-')}.exe` : parts.join('-');
+  // otherwise construct the filename
+  const filename = getFilename(version, {os, architecture, slim});
 
   // if an s3 release alias
   if (s3Releases.includes(version) || version.includes('preview')) {

--- a/utils/get-filename.js
+++ b/utils/get-filename.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const {s3Releases} = require('./get-convenience-aliases');
+
+module.exports = (version, {os, architecture, slim = false} = {}) => {
+  // start by building the lando file string
+  const parts = ['lando'];
+  parts.push(os === 'Windows' ? 'win' : os.toLowerCase());
+  parts.push(architecture.toLowerCase());
+
+  // if version is a dev release from s3
+  // @TODO: we allow s3 convenience aliases with major version stuff eg 4-dev but we dont actually
+  // have those releases labeled in S3, thats fine with just Lando 3 but with Lando 4 we probably need
+  // to have ALL of the below
+  //
+  // https://files.lando.dev/cli/lando-macos-arm64-dev
+  // https://files.lando.dev/cli/lando-macos-arm64-3-dev
+  // https://files.lando.dev/cli/lando-macos-arm64-4-dev
+  //
+  // right now we basically just strip the version
+  if (s3Releases.includes(version)) {
+    // add the s3 alias
+    parts.push(version.split('-').length === 2 ? version.split('-')[1] : version.split('-')[0]);
+  // otherwise append the version
+  } else parts.push(version);
+
+  // add slim if needed
+  if (slim) parts.push('slim');
+
+  // and add special handling for windows
+  return os === 'Windows' ? `${parts.join('-')}.exe` : parts.join('-');
+};

--- a/utils/resolve-version-spec.js
+++ b/utils/resolve-version-spec.js
@@ -6,10 +6,11 @@ const path = require('path');
 const semver = require('semver');
 const tc = require('@actions/tool-cache');
 
+const getFilename = require('./get-filename');
 const isValidUrl = require('./is-valid-url');
 const {s3Releases, gitHubReleases} = require('./get-convenience-aliases');
 
-module.exports = (spec, releases = [], dmv = 3) => {
+module.exports = (spec, releases = [], dmv = 3, {os, architecture, slim = false} = {}) => {
   // if spec is a file that exists relative to GITHUB_WORKSPACE then set spec to absolute path based on that
   if (!path.isAbsolute(spec) && fs.existsSync(path.join(process.env['GITHUB_WORKSPACE'], spec))) {
     spec = path.join(process.env['GITHUB_WORKSPACE'], spec);
@@ -40,13 +41,20 @@ module.exports = (spec, releases = [], dmv = 3) => {
   if (gitHubReleases.includes(spec)) {
     const mv = spec.split('-').length === 1 ? dmv : spec.split('-')[0];
     const includeEdge = spec.split('-').length === 1 ? spec.split('-')[0] === 'edge' : spec.split('-')[1] === 'edge';
+    const fparts = getFilename('REPLACE', {os, architecture, slim}).split('REPLACE');
+    const assetmatcher = new RegExp(`^${fparts[0]}v[0-9]+\\.[0-9]+\\.[0-9]+(?:-[a-z0-9.]+)${fparts[1]}$`);
 
     // filter based on release type and major version and validity etc
     releases = releases
       .filter(release => includeEdge ? true : release.prerelease === false)
       .filter(release => semver.valid(semver.clean(release.tag_name)) !== null)
-      .filter(release => semver.satisfies(release.tag_name, `>=${mv} <${mv + 1}`,
-        {loose: true, includePrerelease: true}));
+      .filter(release => semver.satisfies(release.tag_name, `>=${mv} <${mv + 1}`, {loose: true, includePrerelease: true})) // eslint-disable-line max-len
+      .filter(release => Array.isArray(release.assets))
+      .map(release => ({
+        ...release,
+        binaries: release.assets.map(asset => asset.name).filter(name => assetmatcher.test(name)),
+      }))
+      .filter(release => release.binaries.length > 0);
 
     // theoretically our spec should be at the top so reset to that
     spec = releases[0].tag_name;


### PR DESCRIPTION
…ases with hitherto unpopulated assets

### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)

- [ ] I've updated this PR with the latest code from `main`
- [ ] I've done a cursory QA pass of my code locally
- [ ] I've ensured all automated status check and tests pass
- [ ] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [ ] I've written a unit or functional test for my code
- [ ] I've updated relevant documentation it my code changes it
- [ ] I've updated this repo's README if my code changes it
- [ ] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
