### PR TITLE
Prevent word splitting

### DIFF
--- a/.github/workflows/pr-windows-script-dest-tests.yml
+++ b/.github/workflows/pr-windows-script-dest-tests.yml
@@ -24,4 +24,5 @@ jobs:
         shell: powershell
         run: |
           .\setup-lando.ps1 -Dest "${{ matrix.dest }}"
-          lando version --all
+          $LANDO_EXE = "${{ matrix.dest }}\lando.exe"
+          & $LANDO_EXE version --all

--- a/.github/workflows/pr-windows-script-dest-tests.yml
+++ b/.github/workflows/pr-windows-script-dest-tests.yml
@@ -1,0 +1,27 @@
+name: Windows Script Destination Tests
+
+on:
+  pull_request:
+
+jobs:
+  setup-lando-windows-dest-test:
+    runs-on: windows-2022
+    env:
+      LANDO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        dest:
+          - $env:APPDATA\Lando\bin
+          - $env:USERPROFILE\My Lando\bin
+          - C:\tools
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Lando at ${{ matrix.dest }}
+        shell: powershell
+        run: |
+          .\setup-lando.ps1 -Dest "${{ matrix.dest }}"
+          lando version --all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-* Improved Windows setup script's handling of spaces in parameters and paths
-* Fixed issue where Windows setup script would fail if -Dest directory does not exist
-* Added automated tests for Windows setup script with -Dest parameter
+* Fixed various "space in path" issues with Windows installer script [#87](https://github.com/lando/setup-lando/issues/87) [#51](https://github.com/lando/setup-lando/issues/51)
+* Fixed issue where Windows setup script would fail if `-Dest` directory does not exist
 
 ## v3.7.2 - [December 11, 2024](https://github.com/lando/setup-lando/releases/tag/v3.7.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Improved Windows setup script's handling of spaces in parameters and paths
+* Fixed issue where Windows setup script would fail if -Dest directory does not exist
+* Added automated tests for Windows setup script with -Dest parameter
+
 ## v3.7.2 - [December 11, 2024](https://github.com/lando/setup-lando/releases/tag/v3.7.2)
 
 * Fixed bug unintentionally disabling `lando setup` on `POSIX` for Lando `<3.24`

--- a/setup-lando.ps1
+++ b/setup-lando.ps1
@@ -313,7 +313,7 @@ function Invoke-LandoSetup {
   if ($Debug) {$landoSetupCommand += " --debug"}
 
   try {
-    Invoke-Expression $landoSetupCommand
+    Invoke-Expression "$landoSetupCommand"
     if ($LASTEXITCODE -ne 0) {
       throw "'lando setup' failed with exit code $LASTEXITCODE."
     }

--- a/setup-lando.ps1
+++ b/setup-lando.ps1
@@ -99,8 +99,8 @@ $resolvedVersion = $null
 #  -NewPath <path> : Path to add
 function Add-ToPath {
   param(
-		[Parameter(Mandatory, Position = 0)]
-		[string]$NewPath
+    [Parameter(Mandatory, Position = 0)]
+    [string]$NewPath
   )
   Write-Debug "Adding $NewPath to system PATH..."
   $regPath = "registry::HKEY_CURRENT_USER\Environment"
@@ -130,8 +130,8 @@ function Add-ToPath {
 
 function Add-WrapperScript {
   param(
-		[Parameter(Mandatory)]
-		[string]$Location,
+    [Parameter(Mandatory)]
+    [string]$Location,
     [string]$Symlink = $script:SYMLINKER
   )
 
@@ -187,11 +187,11 @@ function Confirm-Environment {
 
   # Set up our working directories
   if (-not (Test-Path "$LANDO_DATADIR" -ErrorAction SilentlyContinue)) {
-    Write-Debug "Creating destination directory $LANDO_DATADIR..."
+    Write-Debug "Creating data directory $LANDO_DATADIR..."
     New-Item -ItemType Directory -Path $LANDO_DATADIR -Force | Out-Null
   }
   if (-not (Test-Path "$LANDO_BINDIR" -ErrorAction SilentlyContinue)) {
-    Write-Debug "Creating destination directory $LANDO_BINDIR..."
+    Write-Debug "Creating bin directory $LANDO_BINDIR..."
     New-Item -ItemType Directory -Path $LANDO_BINDIR -Force | Out-Null
   }
 }
@@ -217,19 +217,19 @@ function Get-FriendlySize {
 function Get-Lando {
   param(
     [Parameter(Mandatory)]
-		[string]$Url,
-		[string]$Dest = "$script:LANDO_TMPDIR"
+    [string]$Url,
+    [string]$TmpDest = "$script:LANDO_TMPDIR"
   )
 
-  # Ensure dest exist
-  if (-not (Test-Path "$Dest" -ErrorAction SilentlyContinue)) {
-    Write-Debug "Creating destination directory $Dest..."
-    New-Item -ItemType Directory -Path $Dest -Force | Out-Null
+  # Ensure TmpDest exist
+  if (-not (Test-Path "$TmpDest" -ErrorAction SilentlyContinue)) {
+    Write-Debug "Creating temporary destination directory $TmpDest..."
+    New-Item -ItemType Directory -Path $TmpDest -Force | Out-Null
   }
 
   # Add the file part
-  $Dest = "$Dest\$(Get-Random).exe"
-  Write-Host "Fetching Lando $script:Version from $Url to $Dest..."
+  $TmpDest = "$TmpDest\$(Get-Random).exe"
+  Write-Host "Fetching Lando $script:Version from $Url to $TmpDest..."
 
   # Save current colors
   $Host.PrivateData.ProgressForegroundColor = "White";
@@ -238,14 +238,14 @@ function Get-Lando {
   # If file url then just move it and return
   if ($Url.StartsWith("file://")) {
     $Source = $Url.TrimStart("file://");
-    Copy-Item -Path "$Source" -Destination "$Dest"> -Force
-    Write-Debug("Moved local lando from $Source to $Dest");
-    return $Dest;
+    Copy-Item -Path "$Source" -Destination "$TmpDest"> -Force
+    Write-Debug("Moved local lando from $Source to $TmpDest");
+    return $TmpDest;
   }
 
   Write-Progress -Activity "Downloading Lando $script:Version" -Status "Preparing..." -PercentComplete 0
 
-  $outputFileStream = [System.IO.FileStream]::new($Dest, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
+  $outputFileStream = [System.IO.FileStream]::new($TmpDest, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
   try {
     Add-Type -AssemblyName System.Net.Http
     $httpClient = New-Object System.Net.Http.HttpClient
@@ -296,7 +296,7 @@ function Get-Lando {
   }
   Write-Progress -Activity "Downloading Lando $script:resolvedVersion" -Completed
 
-  return $Dest;
+  return $TmpDest;
 }
 
 # Runs the "lando setup" command if Lando is at least version 3.21.0
@@ -657,6 +657,8 @@ If ($Dest -eq $LANDO_BINDIR) {
 
 # Otherwise just move directly to dest and link
 } else {
+  # Create the destination directory if it doesn't exist
+  New-Item -ItemType Directory -Path (Split-Path -Path $LANDO -Parent) -Force | Out-Null
   Move-Item -Path "$LANDO_TMPFILE" -Destination "$LANDO" -Force
   Add-WrapperScript -Location "$LANDO"
 }

--- a/setup-lando.ps1
+++ b/setup-lando.ps1
@@ -57,25 +57,27 @@ $Host.PrivateData.DebugBackgroundColor = $Host.UI.RawUI.BackgroundColor
 
 function Confirm-EnvIsSet {
   param(
-		[Parameter(Mandatory)]
-		[string]$Var
+    [Parameter(Mandatory)]
+    [string]$Var
   )
-	$value = [System.Environment]::GetEnvironmentVariable($Var);
-	return $value -and $value.Trim() -ne ""
+  $value = [System.Environment]::GetEnvironmentVariable($Var);
+  return $value -and $value.Trim() -ne ""
 }
 
 function Get-SystemArchitecture {
-	# Get from env
-	$arch = if ($env:PROCESSOR_ARCHITEW6432) {$env:PROCESSOR_ARCHITEW6432} else {$env:PROCESSOR_ARCHITECTURE}
+  # Get from env
+  $arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
 
-	# Normalize for our purposes
-	if ($arch -eq "AMD64") {
-		return "x64"
-	} elseif ($arch === "ARM64") {
-		return "arm64"
-	} else {
-		return $arch
-	}
+  # Normalize for our purposes
+  if ($arch -eq "AMD64") {
+    return "x64"
+  }
+  elseif ($arch = == "ARM64") {
+    return "arm64"
+  }
+  else {
+    return $arch
+  }
 }
 
 # Config of sorts
@@ -339,42 +341,43 @@ function Get-SemanticVersionInfo {
     $patch = [int]$Matches[3]
 
     return @{
-      Major = $major
-      Minor = $minor
-      Patch = $patch
+      Major      = $major
+      Minor      = $minor
+      Patch      = $patch
       PreRelease = $Matches[4]
-      Build = $Matches[5]
-      Version = "${major}.${minor}.${patch}"
-      Raw = "$Version"
+      Build      = $Matches[5]
+      Version    = "${major}.${minor}.${patch}"
+      Raw        = "$Version"
     }
-  } else {
+  }
+  else {
     throw "Invalid semantic version: $Version"
   }
 }
 
 function Resolve-Input {
-	param (
-		[Parameter(Mandatory)]
-		[string]$InputVar,
-		[Parameter(Mandatory)]
-		[string]$DefaultValue,
-		[string[]]$EnvVars=@()
-	)
+  param (
+    [Parameter(Mandatory)]
+    [string]$InputVar,
+    [Parameter(Mandatory)]
+    [string]$DefaultValue,
+    [string[]]$EnvVars = @()
+  )
 
-	# if the user has modified the input value from the default then just return inputvar
-	if ($InputVar -ne $DefaultValue) {
-		return $InputVar;
-	}
+  # if the user has modified the input value from the default then just return inputvar
+  if ($InputVar -ne $DefaultValue) {
+    return $InputVar;
+  }
 
-	# otherwise lets try to set it with an envvar if possible
-	foreach ($var in $EnvVars) {
-		Write-Debug "$var $(Confirm-EnvIsSet -Var "$var")"
-		if (Confirm-EnvIsSet -Var "$var") {
-			return [System.Environment]::GetEnvironmentVariable($var);
-		}
-	}
+  # otherwise lets try to set it with an envvar if possible
+  foreach ($var in $EnvVars) {
+    Write-Debug "$var $(Confirm-EnvIsSet -Var "$var")"
+    if (Confirm-EnvIsSet -Var "$var") {
+      return [System.Environment]::GetEnvironmentVariable($var);
+    }
+  }
 
-	return $DefaultValue
+  return $DefaultValue
 }
 
 function Resolve-Version {
@@ -441,10 +444,12 @@ function Resolve-VersionPath {
 
   if ([System.IO.Path]::IsPathRooted($Version)) {
     return $Version
-  } else {
+  }
+  else {
     try {
       return Resolve-Path $Version | ForEach-Object { $_.Path }
-    } catch {
+    }
+    catch {
       return $Version
     }
   }
@@ -546,7 +551,8 @@ function Wait-ForUser {
 
   if ($key.Key -eq "Enter") {
     Write-Debug "User confirmed. Continuing..."
-  } else {
+  }
+  else {
     Write-Debug "User cancelled with '$($key.Key)'. Exiting..."
     exit 0
   }
@@ -572,7 +578,7 @@ $Version = Resolve-Input -InputVar $Version -DefaultValue "stable" -EnvVars @("L
 
 # Resolve arch if auto
 if ($Arch -eq "auto") {
-	$Arch = $SYSTEM_ARCHITECTURE;
+  $Arch = $SYSTEM_ARCHITECTURE;
 }
 
 Write-Debug "Running script with resolved inputs:"
@@ -655,8 +661,9 @@ If ($Dest -eq $LANDO_BINDIR) {
   Move-Item -Path "$LANDO_TMPFILE" -Destination "$HIDDEN_LANDO" -Force
   Add-WrapperScript -Location "$HIDDEN_LANDO"
 
-# Otherwise just move directly to dest and link
-} else {
+  # Otherwise just move directly to dest and link
+}
+else {
   # Create the destination directory if it doesn't exist
   New-Item -ItemType Directory -Path (Split-Path -Path $LANDO -Parent) -Force | Out-Null
   Move-Item -Path "$LANDO_TMPFILE" -Destination "$LANDO" -Force


### PR DESCRIPTION
* Improved Windows setup script's handling of spaces in parameters and paths
* Fixed issue where Windows setup script would fail if -Dest directory does not exist
* Added automated tests for Windows setup script with -Dest parameter

Also fixed some code formatting in the setup ps1.

resolves #87
resolves #51 