### PR TITLE
fix bug causing newer midcore release aliases to not be preferred on …

### DIFF
--- a/.github/workflows/pr-actions-env-version.yml
+++ b/.github/workflows/pr-actions-env-version.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           npm clean-install --prefer-offline --frozen-lockfile
           npm run prepare
+          rm -f .lando-version
       - name: Setup Lando version ${{ matrix.lando-version }}
         uses: ./
         env:

--- a/.github/workflows/pr-actions-env-version.yml
+++ b/.github/workflows/pr-actions-env-version.yml
@@ -1,10 +1,10 @@
-name: Actions Version Tests
+name: Actions Version Env Tests
 
 on:
   pull_request:
 
 jobs:
-  setup-lando-actions-versions-test:
+  setup-lando-actions-env-test:
     runs-on: ${{ matrix.os }}
     env:
       LANDO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -16,8 +16,6 @@ jobs:
         node-version:
           - '20'
         lando-version:
-          - '3.x'
-          - '>2'
           - '3'
           - '3.14'
           - '3.14.0'
@@ -27,19 +25,6 @@ jobs:
           - '3-stable-slim'
           - '3-edge'
           - '3-edge-slim'
-          - '3-latest'
-          - '3-dev'
-          - '3-dev-slim'
-          - 'stable'
-          - 'edge'
-          - 'latest'
-          - 'dev'
-          - 'pm-preview'
-          - 'https://github.com/lando/legacy-cli/releases/download/v3.18.0/lando-linux-x64-v3.18.0'
-          - '/home/runner/work/setup-lando/setup-lando/bin/lando'
-          - './bin/lando'
-          - ''
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,6 +41,5 @@ jobs:
           npm run prepare
       - name: Setup Lando version ${{ matrix.lando-version }}
         uses: ./
-        with:
-          lando-version: ${{ matrix.lando-version }}
-          lando-version-file: false
+        env:
+          LANDO_VERSION: ${{ matrix.lando-version }}

--- a/.github/workflows/pr-actions-versions-tests.yml
+++ b/.github/workflows/pr-actions-versions-tests.yml
@@ -55,8 +55,8 @@ jobs:
           npm clean-install --prefer-offline --frozen-lockfile
           npm run prepare
       - name: Setup Lando version ${{ matrix.lando-version }}
-        env:
-          LANDO_VERSION: 3.22.0
+        # env:
+        #   LANDO_VERSION: 3.22.0
         uses: ./
         with:
           lando-version: ${{ matrix.lando-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed bug causing release aliases to return outdated versions with new midcores
+
 ## v3.7.4 - [March 23, 2025](https://github.com/lando/setup-lando/releases/tag/v3.7.4)
 
 * Switched POSIX `LANDO_TMPFILE` to use `mktemp`. Fixes [#41](https://github.com/lando/setup-lando/issues/41).

--- a/setup-lando.sh
+++ b/setup-lando.sh
@@ -462,7 +462,7 @@ major_minor() {
   )"
 }
 
-# shellcheck disable=SC2317
+# shellcheck disable=SC2329
 test_curl() {
   if [[ ! -x "$1" ]]; then
     return 1

--- a/utils/resolve-version-spec.js
+++ b/utils/resolve-version-spec.js
@@ -42,7 +42,7 @@ module.exports = (spec, releases = [], dmv = 3, {os, architecture, slim = false}
     const mv = spec.split('-').length === 1 ? dmv : spec.split('-')[0];
     const includeEdge = spec.split('-').length === 1 ? spec.split('-')[0] === 'edge' : spec.split('-')[1] === 'edge';
     const fparts = getFilename('REPLACE', {os, architecture, slim}).split('REPLACE');
-    const assetmatcher = new RegExp(`^${fparts[0]}v[0-9]+\\.[0-9]+\\.[0-9]+(?:-[a-z0-9.]+)${fparts[1]}$`);
+    const assetmatcher = new RegExp(`^${fparts[0]}v[0-9]+\\.[0-9]+\\.[0-9]+(?:-[a-z0-9.]+)?${fparts[1]}$`);
 
     // filter based on release type and major version and validity etc
     releases = releases


### PR DESCRIPTION
…some release aliases

### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)

- [ ] I've updated this PR with the latest code from `main`
- [ ] I've done a cursory QA pass of my code locally
- [ ] I've ensured all automated status check and tests pass
- [ ] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [ ] I've written a unit or functional test for my code
- [ ] I've updated relevant documentation it my code changes it
- [ ] I've updated this repo's README if my code changes it
- [ ] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
